### PR TITLE
Add contract-call strategy

### DIFF
--- a/src/strategies/contract-call/README.md
+++ b/src/strategies/contract-call/README.md
@@ -1,0 +1,81 @@
+# Contract call strategy
+
+Allows any contract method to be used to calculate voter scores.
+
+## Examples
+
+Can be used instead of the erc20-balance-of strategy, the space config will look like this:
+
+```JSON
+{
+  "strategies": [
+    ["contract-call", {
+      // token address
+      "address": "0x6887DF2f4296e8B772cb19479472A16E836dB9e0",
+      // token decimals
+      "decimals": 18,
+      // token symbol
+      "symbol": "DAI",
+      // ABI for balanceOf method
+      "methodABI": {
+        "constant": true,
+        "inputs": [{
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }],
+        "name": "balanceOf",
+        "outputs": [{
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      }
+    }],
+  ]
+}
+```
+
+You can call methods with multiple inputs in any contract:
+
+```JSON
+{
+  "strategies": [
+    ["contract-call", {
+      // contract address
+      "address": "0x6887DF2f4296e8B772cb19479472A16E836dB9e0",
+      // output decimals
+      "decimals": 18,
+      // strategy symbol
+      "symbol": "mySCORE",
+      // arguments are passed to the method; "%{address}" is replaced with the voter's address; default value ["%{address}"]
+      "args": ["0x6887DF2f4296e8B772cb19479472A16E836dB9e0", "%{address}"], 
+      // method ABI, output type should be uint256
+      "methodABI": {
+        "constant": true,
+        "inputs": [{
+          "internalType": "address",
+          "name": "_someAddress",
+          "type": "address"
+        }, {
+          "internalType": "address",
+          "name": "_voterAddress",
+          "type": "address"
+        }],
+        "name": "totalScoresFor",
+        "outputs": [{
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+      }
+    }],
+  ]
+}
+```

--- a/src/strategies/contract-call/index.ts
+++ b/src/strategies/contract-call/index.ts
@@ -1,0 +1,37 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+function getArgs(options, address: string) {
+  const args: Array<string | number> = options.args || ['%{address}'];
+  return args.map(arg =>
+    typeof arg === 'string' ? arg.replace(/%{address}/g, address) : arg
+  );
+}
+
+export async function strategy(
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    [options.methodABI],
+    addresses.map((address: any) => [
+      options.address,
+      options.methodABI.name,
+      getArgs(options, address)
+    ]),
+    { blockTag }
+  );
+
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      parseFloat(formatUnits(value.toString(), options.decimals))
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -4,6 +4,7 @@ import { strategy as erc20BalanceOfFixedTotal } from './erc20-balance-of-fixed-t
 import { strategy as erc20BalanceOfCv } from './erc20-balance-of-cv';
 import { strategy as makerDsChief } from './maker-ds-chief';
 import { strategy as uni } from './uni';
+import { strategy as contractCall } from './contract-call';
 
 export default {
   balancer,
@@ -11,5 +12,6 @@ export default {
   'erc20-balance-of-fixed-total': erc20BalanceOfFixedTotal,
   'erc20-balance-of-cv': erc20BalanceOfCv,
   'maker-ds-chief': makerDsChief,
-  'uni': uni
+  'uni': uni,
+  'contract-call': contractCall
 };


### PR DESCRIPTION
Added contract-call strategy that allows any contract method to be used to calculate voter scores.
